### PR TITLE
Support both Carbon and CarbonImmutable

### DIFF
--- a/src/Console/Commands/ScheduleCalendarCommand.php
+++ b/src/Console/Commands/ScheduleCalendarCommand.php
@@ -10,6 +10,7 @@ use Exception;
 use Carbon\Carbon;
 use Cron\CronExpression;
 use Carbon\CarbonPeriod;
+use Carbon\CarbonInterface;
 use Illuminate\Console\Command;
 use Illuminate\Console\Application;
 use Symfony\Component\Console\Terminal;
@@ -181,7 +182,7 @@ class ScheduleCalendarCommand extends Command
      * Map scheduled tasks to datetime array.
      * @throws Exception
      */
-    private function mapTasks(Schedule $schedule, Carbon $start, Carbon $end): void
+    private function mapTasks(Schedule $schedule, CarbonInterface $start, CarbonInterface $end): void
     {
         $events = collect($schedule->events());
 
@@ -334,7 +335,7 @@ class ScheduleCalendarCommand extends Command
     /**
      * Print hour line.
      */
-    private function printHourLine(Carbon $startHour): void
+    private function printHourLine(CarbonInterface $startHour): void
     {
         for ($hours = 0; $hours < $this->hoursPerLine; $hours++) {
             $this->output->write($startHour->format('H:i'));


### PR DESCRIPTION
When settings the Carbon class used globally throughout Laravel to `CarbonImmutable` (`Date::use(CarbonImmutable::class)`), the command fails:

`Indeev\LaravelScheduleCalendar\Console\Commands\ScheduleCalendarCommand::printHourLine(): Argument #1 ($startHour) must be of type Carbon\Carbon, Carbon\CarbonImmutable given, called in [...]/Laravel-Schedule-Calendar/src/Console/Commands/ScheduleCalendarCommand.php on line 293`

This is because `$this->option('date')` will return the date as an instance of `CarbonImmutable`, while the `mapTasks()` and `printHourLine()` functions expects an instance of `Carbon`.

This PR changes the `Carbon` type hints to use `CarbonInterface` instead, supporting both `Carbon` and `CarbonImmutable`.